### PR TITLE
Bug Fix -  Error gets thrown when supplying custom tls config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,7 @@ build-docker:
 
 build-cli: clean
 	-mkdir ./cli/build
-	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o ../../cli/build/migrate.linux-amd64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -a -o ../../cli/build/migrate.linux-armv7 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o ../../cli/build/migrate.linux-arm64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -o ../../cli/build/migrate.darwin-amd64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -a -o ../../cli/build/migrate.windows-386.exe -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -a -o ../../cli/build/migrate.windows-amd64.exe -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cli/build && find . -name 'migrate*' | xargs -I{} tar czf {}.tar.gz {}
-	cd ./cli/build && shasum -a 256 * > sha256sum.txt
-	cat ./cli/build/sha256sum.txt
-
+	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /go/bin/migratecli -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
 
 clean:
 	-rm -r ./cli/build

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -13,15 +13,11 @@ import (
 	nurl "net/url"
 	"strconv"
 	"strings"
-)
 
-import (
 	"github.com/go-sql-driver/mysql"
-	"github.com/hashicorp/go-multierror"
-)
-
-import (
 	"github.com/golang-migrate/migrate/v4/database"
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -117,7 +113,49 @@ func extractCustomQueryParams(c *mysql.Config) (map[string]string, error) {
 	return customQueryParams, nil
 }
 
+// extractDSNParam extracts the value of a param specified in the
+// DSN string.
+func extractDSNParam(queryString, param string) (string, error) {
+	for _, v := range strings.Split(queryString, "&") {
+		p := strings.SplitN(v, "=", 2)
+		if len(p) != 2 {
+			continue
+		}
+		if p[0] == param {
+			return nurl.QueryUnescape(p[1])
+		}
+	}
+	return "", nil
+}
+
+// ensureRegisteredTLSConfig registers a config with the supplied tls name, if not using a default config.
+// If the user is supplying a custom tls configuration, i.e. needing to supply certs using the `x-tls-*`
+// query params in the DSN, we pre-register an empty config with that name,. This avoids the errors
+// occurring when making the call to mysql.ParseDSN() which tries to lookup the tls config and throws
+// an error if it doesn't exist.
+func ensureRegisteredTLSConfig(ctls string) error {
+	switch ctls {
+	case "true", "false", "skip-verify", "preferred", "":
+		return nil
+	default:
+		return mysql.RegisterTLSConfig(ctls, &tls.Config{})
+	}
+}
+
 func urlToMySQLConfig(url string) (*mysql.Config, error) {
+	dsn := strings.Split(url, "?")
+	if len(dsn) > 1 {
+		dsnParams := dsn[1]
+		tlsConfig, err := extractDSNParam(dsnParams, "tls")
+		if err != nil {
+			return nil, errors.Wrap(err, "extracting `tls` DSN param")
+		}
+		err = ensureRegisteredTLSConfig(tlsConfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	config, err := mysql.ParseDSN(strings.TrimPrefix(url, "mysql://"))
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/mutecomm/go-sqlcipher/v4 v4.4.0
 	github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8
 	github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba
+	github.com/pkg/errors v0.9.1
 	github.com/snowflakedb/gosnowflake v1.3.5
 	github.com/stretchr/testify v1.5.1
 	github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51 // indirect


### PR DESCRIPTION
This PR puts in a bug fix to allow specifying a custom TLS config. The issue here is a call is being made to mysql.ParseDSN to parse the DSN connection string into a config object. This tool expects a value for the tls query parameter that needs to be something other than "true", "false", "skip-verify", or "preferred", in order for it to use the custom configuration we are providing it. The problem occurs because when the [call to mysql.ParseDSN](https://github.com/pulumi/golang-migrate/blob/9c15b1e30281b8a791d6e4d253e0f5535b2cc0c8/database/mysql/mysql.go#L159) is made it expects the value being passed to tls to be the name of a config that is registered. As part of parsing it it tries to look it up against registered keys, if it doesn't exist, an [error gets thrown saying "invalid / unknown tls config" ](https://github.com/go-sql-driver/mysql/blob/master/dsn.go#L132)ad the code cannot proceeed any further. At this point in time wheThis error gets th ?n the call gets made it is impossible that the config would exist as it doesn't get registered until further downnin the code execution. So the fix here is to pre-register the config if it is not one of the default values, e.g. true, flase, skip-verify, so it doesnt error out when parsing the DSN string. We then [register it "for real" further down the code path](https://github.com/pulumi/golang-migrate/blob/9c15b1e30281b8a791d6e4d253e0f5535b2cc0c8/database/mysql/mysql.go#L216). This does look a bit hacky on the surface, i.e. why not just parse the config after it is registered?, but we need to parse the config to begin with to get a hold of the values in order to register a TLS config to begin with, so we are in somewhat of a chicken-egg scenario in the way the code is implemented here, so I figured this was the safest work around.