### PR TITLE
Add metadata lock retries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ VERSION ?= $(shell git describe --tags 2>/dev/null | cut -c 2-)
 TEST_FLAGS ?=
 REPO_OWNER ?= $(shell cd .. && basename "$$(pwd)")
 COVERAGE_DIR ?= .coverage
+CLI_BUILD_OUTPUT ?= /go/bin/migratecli
 
 build:
 	CGO_ENABLED=0 go build -ldflags='-X main.Version=$(VERSION)' -tags '$(DATABASE) $(SOURCE)' ./cmd/migrate
@@ -14,16 +15,7 @@ build-docker:
 
 build-cli: clean
 	-mkdir ./cli/build
-	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o ../../cli/build/migrate.linux-amd64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -a -o ../../cli/build/migrate.linux-armv7 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o ../../cli/build/migrate.linux-arm64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -o ../../cli/build/migrate.darwin-amd64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -a -o ../../cli/build/migrate.windows-386.exe -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -a -o ../../cli/build/migrate.windows-amd64.exe -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cli/build && find . -name 'migrate*' | xargs -I{} tar czf {}.tar.gz {}
-	cd ./cli/build && shasum -a 256 * > sha256sum.txt
-	cat ./cli/build/sha256sum.txt
-
+	cd ./cmd/migrate && CGO_ENABLED=0 go build -a -o $(CLI_BUILD_OUTPUT) -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
 
 clean:
 	-rm -r ./cli/build

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 	CGO_ENABLED=0 go build -ldflags='-X main.Version=$(VERSION)' -tags '$(DATABASE) $(SOURCE)' ./cmd/migrate
 
 build-docker:
-	CGO_ENABLED=0 go build -a -o build/migrate.linux-386 -ldflags="-s -w -X main.Version=${VERSION}" -tags "$(DATABASE) $(SOURCE)" ./cmd/migrate
+	CGO_ENABLED=0 go build -a -o build/migrate -ldflags="-s -w -X main.Version=${VERSION}" -tags "$(DATABASE) $(SOURCE)" ./cmd/migrate
 
 build-cli: clean
 	-mkdir ./cli/build

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -271,7 +271,7 @@ func (m *Mysql) Open(url string) (database.Driver, error) {
 	}
 
 	metadataLockRetriesParam := customParams["x-metadata-lock-retries"]
-	metadataLockRetries := uint64(60)
+	metadataLockRetries := uint64(0)
 	if metadataLockRetriesParam != "" {
 		metadataLockRetries, err = strconv.ParseUint(metadataLockRetriesParam, 10, 32)
 		if err != nil {

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -6,7 +6,6 @@
 // See this design doc for more on the problem we are trying to solve:
 //  https://docs.google.com/document/d/1TfctnknUy3YHTpt0LmzmWuUHK2Qp3_hGUR446hCZx74/edit
 
-
 package mysql
 
 import (

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -1,6 +1,12 @@
 //go:build go1.9
 // +build go1.9
 
+// This is a copy of github.com/golang-migrate/migrate/v4/cmd/database/mysql/mysql.go
+// It has been extended to support x-metadata-lock-timeout and x-metadata-lock-retries
+// See this design doc for more on the problem we are trying to solve:
+//  https://docs.google.com/document/d/1TfctnknUy3YHTpt0LmzmWuUHK2Qp3_hGUR446hCZx74/edit
+
+
 package mysql
 
 import (
@@ -10,6 +16,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
+	"log"
 	nurl "net/url"
 	"os"
 	"strconv"
@@ -40,10 +47,12 @@ var (
 )
 
 type Config struct {
-	MigrationsTable  string
-	DatabaseName     string
-	NoLock           bool
-	StatementTimeout time.Duration
+	MigrationsTable     string
+	DatabaseName        string
+	NoLock              bool
+	StatementTimeout    time.Duration
+	MetadataLockTimeout uint
+	MetadataLockRetries uint
 }
 
 type Mysql struct {
@@ -253,16 +262,36 @@ func (m *Mysql) Open(url string) (database.Driver, error) {
 		}
 	}
 
+	metadataLockTimeoutParam := customParams["x-metadata-lock-timeout"]
+	metadataLockTimeout := uint64(0)
+	if metadataLockTimeoutParam != "" {
+		metadataLockTimeout, err = strconv.ParseUint(metadataLockTimeoutParam, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse x-metadata-lock-timeout as uint: %w", err)
+		}
+	}
+
+	metadataLockRetriesParam := customParams["x-metadata-lock-retries"]
+	metadataLockRetries := uint64(60)
+	if metadataLockRetriesParam != "" {
+		metadataLockRetries, err = strconv.ParseUint(metadataLockRetriesParam, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse x-metadata-lock-retries as uint: %w", err)
+		}
+	}
+
 	db, err := sql.Open("mysql", config.FormatDSN())
 	if err != nil {
 		return nil, err
 	}
 
 	mx, err := WithInstance(db, &Config{
-		DatabaseName:     config.DBName,
-		MigrationsTable:  customParams["x-migrations-table"],
-		NoLock:           noLock,
-		StatementTimeout: time.Duration(statementTimeout) * time.Millisecond,
+		DatabaseName:        config.DBName,
+		MigrationsTable:     customParams["x-migrations-table"],
+		NoLock:              noLock,
+		StatementTimeout:    time.Duration(statementTimeout) * time.Millisecond,
+		MetadataLockTimeout: uint(metadataLockTimeout),
+		MetadataLockRetries: uint(metadataLockRetries),
 	})
 	if err != nil {
 		return nil, err
@@ -347,12 +376,31 @@ func (m *Mysql) Run(migration io.Reader) error {
 		defer cancel()
 	}
 
-	query := string(migr[:])
-	if _, err := m.conn.ExecContext(ctx, query); err != nil {
-		return database.Error{OrigErr: err, Err: "migration failed", Query: migr}
+	if m.config.MetadataLockTimeout != 0 {
+		query := "SET lock_wait_timeout=?"
+		if _, err := m.conn.ExecContext(ctx, query, m.config.MetadataLockTimeout); err != nil {
+			return &database.Error{OrigErr: err, Query: []byte(query)}
+		}
 	}
 
-	return nil
+	retries := uint(0)
+	for retries <= m.config.MetadataLockRetries {
+		query := string(migr[:])
+		if _, err := m.conn.ExecContext(ctx, query); err != nil {
+			// ERROR 1205: Lock wait timeout exceeded
+			if val, ok := err.(*mysql.MySQLError); ok && val.Number == 1205 {
+				log.Println("Failed to grab metadata lock after", m.config.MetadataLockTimeout, "seconds. Migration is retrying...")
+				retries++
+				// Queries can pile up behind the migration while waiting on the lock.
+				// Sleep for a second to give the DB a little breathing room.
+				time.Sleep(time.Second)
+				continue
+			}
+			return database.Error{OrigErr: err, Err: "migration failed", Query: migr}
+		}
+		return nil
+	}
+	return database.Error{Err: fmt.Sprint("Couldn't obtain metadata lock after ", m.config.MetadataLockRetries, " retries"), Query: migr}
 }
 
 func (m *Mysql) SetVersion(version int, dirty bool) error {


### PR DESCRIPTION
This extends the MySQL driver to set a metadata lock timeout and retry migrations if the lock can't be acquired quickly.

This builds on #12, and they should be merged at the same time to prevent disrupting consumers of this repo.